### PR TITLE
Reduce warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,3 +94,7 @@ rrte-plugin = { path = "crates/rrte-plugin" }
 # Core engine dependencies (no windowing here - that's for applications)
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 wgpu = { version = "0.19" }
+
+[features]
+gpu = []
+plugins = []

--- a/crates/rrte-core/src/lib.rs
+++ b/crates/rrte-core/src/lib.rs
@@ -1,3 +1,7 @@
+//! Core engine infrastructure.
+//!
+//! This crate contains the main engine loop and foundational systems.
+
 pub mod engine;
 pub mod time;
 pub mod input;

--- a/crates/rrte-ecs/src/lib.rs
+++ b/crates/rrte-ecs/src/lib.rs
@@ -1,3 +1,7 @@
+//! ECS (Entity Component System) utilities.
+//!
+//! This crate provides a minimal ECS implementation used by the engine.
+
 pub mod entity;
 pub mod component;
 pub mod system;

--- a/crates/rrte-ecs/src/query.rs
+++ b/crates/rrte-ecs/src/query.rs
@@ -57,6 +57,14 @@ pub struct ComplexQuery {
 }
 
 impl ComplexQuery {
+    pub fn required(&self) -> &[std::any::TypeId] {
+        &self.required_components
+    }
+
+    pub fn optional(&self) -> &[std::any::TypeId] {
+        &self.optional_components
+    }
+
     pub fn execute(&self, entities: &[Entity]) -> Vec<Entity> {
         // This would need proper implementation
         entities.to_vec()

--- a/crates/rrte-ecs/src/system.rs
+++ b/crates/rrte-ecs/src/system.rs
@@ -1,4 +1,4 @@
-use crate::{Entity, Component, ComponentStorage};
+use crate::{Entity, ComponentStorage};
 
 /// A trait for systems that operate on entities and components
 pub trait System {

--- a/crates/rrte-ecs/src/world.rs
+++ b/crates/rrte-ecs/src/world.rs
@@ -28,7 +28,7 @@ impl World {
     pub fn destroy_entity(&mut self, entity: Entity) {
         self.entities.retain(|&e| e != entity);
         // Remove components for this entity from all managers
-        for manager in self.component_managers.values_mut() {
+        for _manager in self.component_managers.values_mut() {
             // This would need to be implemented properly
             // manager.remove_component(entity);
         }

--- a/crates/rrte-math/src/lib.rs
+++ b/crates/rrte-math/src/lib.rs
@@ -23,7 +23,6 @@ pub mod constants {
 
 /// Utility functions for common mathematical operations
 pub mod utils {
-    use super::*;
 
     /// Clamp a value between min and max
     pub fn clamp(value: f32, min: f32, max: f32) -> f32 {

--- a/crates/rrte-math/src/ray.rs
+++ b/crates/rrte-math/src/ray.rs
@@ -1,4 +1,4 @@
-use glam::{Vec3, Vec4};
+use glam::Vec3;
 use serde::{Deserialize, Serialize};
 
 /// A ray in 3D space with origin and direction

--- a/crates/rrte-plugin/src/lib.rs
+++ b/crates/rrte-plugin/src/lib.rs
@@ -1,3 +1,7 @@
+//! Plugin infrastructure for extending the engine.
+//!
+//! Provides loading and registration utilities for dynamic plugins.
+
 pub mod plugin;
 pub mod loader;
 pub mod registry;

--- a/crates/rrte-plugin/src/registry.rs
+++ b/crates/rrte-plugin/src/registry.rs
@@ -9,4 +9,9 @@ pub struct PluginRegistry {
 
 impl PluginRegistry {
     pub fn new() -> Self { Self { plugins: HashMap::new() } }
+
+    /// Return the number of registered plugins
+    pub fn plugin_count(&self) -> usize {
+        self.plugins.len()
+    }
 }

--- a/crates/rrte-renderer/src/camera.rs
+++ b/crates/rrte-renderer/src/camera.rs
@@ -22,8 +22,11 @@ pub enum ProjectionType {
 /// Camera component for rendering
 #[derive(Debug, Clone)]
 pub struct Camera {
+    /// Camera transform in world space
     pub transform: Transform,
+    /// Projection information
     pub projection: ProjectionType,
+    /// Whether the camera is currently active
     pub is_active: bool,
 }
 
@@ -83,7 +86,7 @@ impl Camera {
         // Ensure self.transform.position is set before calling this
         let forward = (target - self.transform.position).normalize();
         let right = forward.cross(up).normalize();
-        let actual_up = right.cross(forward); // Recalculate up vector to be orthogonal
+        let _actual_up = right.cross(forward); // Recalculate up vector to be orthogonal
         self.transform.rotation = Quat::from_rotation_arc(Vec3::NEG_Z, forward);
         // Note: A more robust look_at might involve creating a rotation matrix
         // from the basis vectors (right, actual_up, -forward) and then converting to Quat.

--- a/crates/rrte-renderer/src/gpu_renderer.rs
+++ b/crates/rrte-renderer/src/gpu_renderer.rs
@@ -1,16 +1,15 @@
-use wgpu::{Device, Queue, Surface, SurfaceConfiguration, TextureFormat};
+use wgpu::{Device, Queue, SurfaceConfiguration, TextureFormat};
 use winit::window::Window;
 use anyhow::Result;
 use std::sync::Arc;
 use wgpu::util::DeviceExt;
-use glam::{Vec3, Mat4};
+use glam::Mat4;
 // use crate::RendererConfig; // Commented out to investigate usage
 use crate::camera::Camera as RendererCamera; // Added import for RendererCamera
-use crate::material::Material; // Added for material handling
 use crate::primitives::Sphere; // Added for sphere handling
 use crate::light::PointLight; // Added for light handling
 use std::collections::HashMap; // Added for material map
-use log::{info, warn, error};
+use log::{info, warn};
 
 /// GPU renderer configuration
 #[derive(Debug, Clone)]

--- a/crates/rrte-renderer/src/lib.rs
+++ b/crates/rrte-renderer/src/lib.rs
@@ -1,15 +1,26 @@
+//! Rendering utilities for the RRTE engine.
+//!
+//! This crate contains CPU and GPU based renderers along with common
+//! primitives, materials and camera types.
+
+/// Raytracing implementation.
 pub mod raytracer;
+/// Material definitions and utilities.
 pub mod material;
+/// Primitive geometry types.
 pub mod primitives;
+/// Scene management structures.
 pub mod scene;
+/// Lighting types.
 pub mod light;
+/// GPU-based renderer implementation.
 pub mod gpu_renderer;
+/// Camera types.
 pub mod camera;
 
 pub use raytracer::*;
 pub use material::*;
 pub use primitives::*;
-pub use scene::*;
 pub use light::*;
 pub use gpu_renderer::{GpuRenderer, GpuRendererConfig};
 pub use camera::*;

--- a/crates/rrte-renderer/src/raytracer.rs
+++ b/crates/rrte-renderer/src/raytracer.rs
@@ -1,4 +1,4 @@
-use rrte_math::{Ray, HitInfo, Vec3, Color};
+use rrte_math::{Ray, HitInfo, Color};
 use crate::{Material, SceneObject, Light, Camera};
 use rayon::prelude::*;
 use std::sync::Arc;

--- a/crates/rrte-scene/src/lib.rs
+++ b/crates/rrte-scene/src/lib.rs
@@ -1,3 +1,8 @@
+//! Scene management utilities for the RRTE engine.
+//!
+//! This crate defines scene data structures used by the renderer
+//! and gameplay systems.
+
 use rrte_math::{Transform, Vec3, Color};
 use rrte_renderer::{SceneObject, Material, Light, primitives::Sphere, light::PointLight};
 use rrte_ecs::{Entity, World, Component};
@@ -8,10 +13,15 @@ use serde::{Deserialize, Serialize};
 /// Scene configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SceneConfig {
+    /// Name of the scene
     pub name: String,
+    /// Global ambient light color
     pub ambient_light: Color,
+    /// Fog color used for atmospheric effects
     pub fog_color: Color,
+    /// Fog density value
     pub fog_density: f32,
+    /// Gravity vector applied to physics objects
     pub gravity: Vec3,
 }
 
@@ -30,8 +40,11 @@ impl Default for SceneConfig {
 /// Scene component for objects that exist in 3D space
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SceneComponent {
+    /// World transform of the entity
     pub transform: Transform,
+    /// Visibility flag
     pub visible: bool,
+    /// Rendering layer mask
     pub layer: u32,
 }
 


### PR DESCRIPTION
## Summary
- add optional `gpu`/`plugins` features
- document public crates and modules
- clean up unused imports and variables
- expose plugin count API

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_683f853569cc8321a280ce3e7cb07317